### PR TITLE
[Objective-c] Created .h and .m files for IOS implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ You can use this in a standalone project (basic cordova project), or into a exis
 
     cordova plugin add cordova-plugin-nativeview --save
 
+### Extra: Native app (_Android/IOS_ native code)
+
+**IOS**
+
+* Install [cocoapods](https://cocoapods.org/)
+* Add this plugin like a `pod`:
+
+```ruby
+# Objective-C version (Default)
+pod 'cordova-plugin-nativeview', '~> 0.0.2'
+
+# Swift version (work in progress)
+pod 'cordova-plugin-nativeview', :git => 'https://github.com/mfdeveloper/cordova-plugin-nativeview.git', :branch => 'swift'
+```
+
+**ANDROID**
+
+Until here, this plugin is not registered on cloud. In future, this plugin will be on [jcenter](https://bintray.com/bintray/jcenter) and/or [mavencentral](https://search.maven.org/). By now, you need:
+
+* From your cordova project, copy the content off `platforms/android/assets/www` folder to your android project (usually, `app/src/main/assets`). Or create a **gradle** task to do this.
+
+* Clone this repo, and copy the class: `src/android/NativeView.java` to your Android project
+
+* Or create a `.jar` or a `.aar` that contains this class, and import like a [Android module dependency](https://developer.android.com/studio/projects/android-library.html#AddDependency)
+
+* Build/Run your android project!
+
 ## Supported Platforms
 
 - ![Android](icons/android.png) Android
@@ -27,7 +54,7 @@ You can use this in a standalone project (basic cordova project), or into a exis
 Shows a native view.
 
 
-**Android**
+**ANDROID**
 
 ```js
 

--- a/cordova-plugin-nativeview.swift.podspec
+++ b/cordova-plugin-nativeview.swift.podspec
@@ -81,7 +81,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/mfdeveloper/cordova-plugin-nativeview.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/mfdeveloper/cordova-plugin-nativeview.git", :branch => "swift" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -92,7 +92,7 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = "src/ios/*.{h,m}"
+  s.source_files  = "src/ios/*.swift"
   #s.exclude_files = "Classes/Exclude"
 
   # s.public_header_files = "Classes/**/*.h"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-nativeview",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "types": "./types/index.d.ts",
   "description": "Start or Back to a native screen/page",
   "author": {
@@ -28,8 +28,7 @@
     "UIViewController",
     "ecosystem:cordova",
     "cordova-android",
-    "cordova-ios",
-    "cordova-tizen"
+    "cordova-ios"
   ],
   "license": "MIT"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-nativeview"
-    version="0.0.1">
+    version="0.0.2">
     <name>Cordova NativeView Plugin</name>
     <description>
         Start or Back to a UIViewController(ios)/Activity(Android) 
@@ -38,7 +38,10 @@
                 <param name="onload" value="true" />
             </feature>
         </config-file>
-
-         <source-file src="src/ios/CDVNativeView.swift" />
+        
+         <header-file src="src/ios/CDVNativeView.h" />
+         <source-file src="src/ios/CDVNativeView.m" />
+         <header-file src="src/ios/InstantiateViewControllerError.h" />
+         <source-file src="src/ios/InstantiateViewControllerError.m" />
     </platform>
 </plugin>

--- a/src/ios/CDVNativeView.h
+++ b/src/ios/CDVNativeView.h
@@ -1,0 +1,15 @@
+//
+//  CDVNativeView.h
+//  IRPF
+//
+//  Created by Michel Felipe on 05/09/17.
+//
+//
+
+#import <Cordova/CDV.h>
+
+@interface CDVNativeView : CDVPlugin
+
+- (void)show:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/ios/CDVNativeView.m
+++ b/src/ios/CDVNativeView.m
@@ -1,0 +1,111 @@
+//
+//  CDVNativeView.m
+//  IRPF
+//
+//  Created by Michel Felipe on 05/09/17.
+//
+//
+
+#import "CDVNativeView.h"
+#import "InstantiateViewControllerError.h"
+#import <UIKit/UIKit.h>
+
+@interface CDVNativeView (hidden)
+
+-(UIViewController*) instantiateViewControllerWithName: (NSString*) name;
+-(UIViewController*) tryInstantiateViewWithName: (NSString*) name;
+
+@end
+
+@implementation CDVNativeView
+
+- (void)show:(CDVInvokedUrlCommand*)command {
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+    
+    NSString* className = [command argumentAtIndex: 0];
+    NSString* storyboardName = @"";
+    
+    UIViewController *viewController = nil;
+    
+    if ([command.arguments count] > 1) {
+        
+        NSString* secondParam = [command argumentAtIndex: 1];
+        
+        if (secondParam != nil) {
+            storyboardName = className;
+            className = secondParam != nil ? secondParam : @"";
+        }
+        
+    }
+    
+    if ([self.viewController navigationController] != nil) {
+        
+        if ([self.viewController.navigationController.viewControllers count] > 1) {
+            [self.viewController.navigationController popViewControllerAnimated: YES];
+        }else{
+            
+            viewController = [self tryInstantiateViewWithName: className];
+            
+            [self.viewController.navigationController pushViewController:viewController animated:YES];
+        }
+        
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        
+    }else if (className.length > 0 ){
+        
+        if ([[NSBundle mainBundle] pathForResource:storyboardName ofType: @"storyboardc"] != nil
+            && storyboardName.length > 0) {
+                
+            UIStoryboard* storyboard = [UIStoryboard storyboardWithName:storyboardName bundle:[NSBundle mainBundle]];
+            
+            viewController = [storyboard instantiateViewControllerWithIdentifier:className];
+            
+            }else{
+                
+                viewController = [self tryInstantiateViewWithName: className];
+            }
+        
+        CDVAppDelegate* appDelegate = [[UIApplication sharedApplication] delegate];
+        appDelegate.window.rootViewController = viewController;
+        
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }else{
+        @try {
+            [self raiseClassNameError];
+        } @catch(InstantiateViewControllerError* e) {
+            NSLog(@"%@", e.reason);
+        }
+    }
+    
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId ];
+}
+
+- (UIViewController*) instantiateViewControllerWithName: (NSString*) name {
+    
+    if ([[NSBundle mainBundle] pathForResource:name ofType: @"nib"]) {
+        return [[UIViewController  alloc] initWithNibName: name bundle: nil];
+    }
+    
+    NSString* message = [[NSString alloc] initWithFormat:@"The ViewController: %@ was not found", name];
+    @throw [[InstantiateViewControllerError alloc] initWithName: @"notFound" reason: message userInfo: nil];
+}
+
+- (UIViewController*) tryInstantiateViewWithName:(NSString *)name {
+    
+    @try {
+        return [self instantiateViewControllerWithName: name];
+    } @catch (InstantiateViewControllerError* e) {
+        NSLog(@"%@", e.reason);
+    }
+    
+    return nil;
+}
+
+- (void) raiseClassNameError {
+    
+    NSString* message = [[NSString alloc] initWithFormat:@"The UIViewController name is required when the project don't have a navigatioController. Please, pass a className by param in JS, like this: 'NativeView.show('MyUIViewController')"];
+    @throw [[InstantiateViewControllerError alloc] initWithName: @"nameNotDefined" reason: message userInfo: nil];
+}
+
+@end

--- a/src/ios/InstantiateViewControllerError.h
+++ b/src/ios/InstantiateViewControllerError.h
@@ -1,0 +1,13 @@
+//
+//  InstantiateViewControllerError.h
+//  IRPF
+//
+//  Created by Michel Felipe on 05/09/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface InstantiateViewControllerError : NSException
+
+@end

--- a/src/ios/InstantiateViewControllerError.m
+++ b/src/ios/InstantiateViewControllerError.m
@@ -1,0 +1,13 @@
+//
+//  InstantiateViewControllerError.m
+//  IRPF
+//
+//  Created by Michel Felipe on 05/09/17.
+//
+//
+
+#import "InstantiateViewControllerError.h"
+
+@implementation InstantiateViewControllerError
+
+@end


### PR DESCRIPTION
Added `Objective-C` support. This was made because the `Swift` version increase the app size substantially, and for some clients, this is awful, mainly if your project had a lot of `Objective-C` files.

The `Swift`version is into [swift](https://github.com/mfdeveloper/cordova-plugin-nativeview/tree/swift) branch. By now, I've got problems to push to [cocoapods](https://cocoapods.org/) because the `CDVNativeView` inherits from `CDVPlugin` (a `pod` require inherit from `NSObject`). By now, this version only works copying this class to your IOS project manually.
